### PR TITLE
Feature/leave callbacks

### DIFF
--- a/examples/material/less/main.less
+++ b/examples/material/less/main.less
@@ -4,8 +4,8 @@ body {
 
 .list-item {
   display: block;
-  padding: 10px;
   margin-bottom: 10px;
+  padding: 10px;
   color: #fff;
   &:last-child {
     margin-bottom: 0;
@@ -18,17 +18,17 @@ body {
   .transition-item {
     position: fixed;
     top: 0;
-    left: 0;
     right: 0;
+    left: 0;
   }
 }
 
 .detail-page {
-  padding: 10px 10px;
-  background-color: #03a9f4;
-  height: 100vh;
-  box-sizing: border-box;
   overflow: hidden;
+  box-sizing: border-box;
+  padding: 10px 10px;
+  height: 100vh;
+  background-color: #03a9f4;
 
   a {
     color: white;
@@ -36,7 +36,7 @@ body {
 
   &.transition-appear {
     transition: transform 1s cubic-bezier(0.7, 0, 0.25, 1),
-      left 1s cubic-bezier(0.7, 0, 0.25, 1),
+    left 1s cubic-bezier(0.7, 0, 0.25, 1),
       right 1s cubic-bezier(0.7, 0, 0.25, 1),
       height 1s cubic-bezier(0.7, 0, 0.25, 1);
   }
@@ -45,11 +45,12 @@ body {
   }
 }
 .list-page {
+  z-index: 2;
+  box-sizing: border-box;
   padding: 20px;
+  height: 100vh;
   background-color: #fff;
   transition: opacity 1s;
-  height: 100vh;
-  box-sizing: border-box;
 
   &.transition-appear {
     opacity: 0.01;

--- a/examples/reveal/less/main.less
+++ b/examples/reveal/less/main.less
@@ -3,26 +3,28 @@ body {
 }
 
 .text-center {
-  text-align: center;
   display: block;
+  text-align: center;
 }
 
 .list-page {
   display: flex;
+
   flex-wrap: wrap;
 }
 
 .list-item {
-  @size: 100px;
   display: block;
+  box-sizing: border-box;
   padding: 10px;
-  color: #fff;
+  padding: 10px;
   width: @size;
   height: @size;
   border-radius: (@size + 20) / 2;
-  padding: 10px;
+  color: #fff;
   text-align: center;
-  box-sizing: border-box;
+
+  @size: 100px;
 }
 
 .trasition-wrapper {
@@ -31,22 +33,22 @@ body {
   .transition-item {
     position: fixed;
     top: 0;
-    left: 0;
     right: 0;
+    left: 0;
   }
 }
 
 .detail-page {
-  padding: 10px 10px;
-  background-color: #03a9f4;
-  height: 100vh;
-  box-sizing: border-box;
   overflow: hidden;
+  box-sizing: border-box;
+  padding: 10px 10px;
+  height: 100vh;
+  background-color: #03a9f4;
 
   a {
     color: white;
   }
-  
+
   h1 {
     margin-top: 60px;
     color: #fff
@@ -64,11 +66,12 @@ body {
   }
 }
 .list-page {
+  z-index: 2;
+  box-sizing: border-box;
   padding: 20px;
+  height: 100vh;
   background-color: #fff;
   transition: opacity 0.5s;
-  height: 100vh;
-  box-sizing: border-box;
 
   &.transition-appear {
     opacity: 0.01;

--- a/examples/simple/less/main.less
+++ b/examples/simple/less/main.less
@@ -4,8 +4,8 @@ body {
 
 .list-item {
   display: block;
-  padding: 10px;
   margin-bottom: 10px;
+  padding: 10px;
   color: #fff;
   &:last-child {
     margin-bottom: 0;
@@ -18,43 +18,64 @@ body {
   .transition-item {
     position: fixed;
     top: 0;
-    left: 0;
     right: 0;
+    left: 0;
   }
 }
 
 .detail-page {
+  overflow: auto;
+  box-sizing: border-box;
   padding: 20px;
+  height: 100vh;
   background-color: #03a9f4;
   transition: transform 0.5s, opacity 0.5s;
-  height: 100vh;
-  box-sizing: border-box;
 
   &.transition-appear {
-    transform: translate3d(100%, 0, 0);
     opacity: 0;
+    transform: translate3d(100%, 0, 0);
   }
 
   &.transition-appear.transition-appear-active {
-    transform: translate3d(0, 0, 0);
     opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  &.transition-leave {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  &.transition-leave.transition-leave-active {
+    opacity: 0;
+    transform: translate3d(100%, 0, 0);
   }
 }
 
 .list-page {
+  overflow: auto;
+  box-sizing: border-box;
   padding: 20px;
+  height: 100vh;
   background-color: #fff;
   transition: transform 0.5s, opacity 0.5s;
-  height: 100vh;
-  box-sizing: border-box;
+  transform: translate3d(0, 0, 0);
 
   &.transition-appear {
-    transform: translate3d(-100%, 0, 0);
     opacity: 0;
+    transform: translate3d(-100%, 0, 0);
   }
 
   &.transition-appear.transition-appear-active {
-    transform: translate3d(0, 0, 0);
     opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  &.transition-leave {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  &.transition-leave.transition-leave-active {
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
   }
 }

--- a/lib/PageTransition.js
+++ b/lib/PageTransition.js
@@ -89,7 +89,7 @@ exports.default = function () {
         var child = this.refs[ref];
         // Dirty way to check if the component is
         // wrapped with react-redux Connect
-        if (child.getWrappedInstance) {
+        if (child && child.getWrappedInstance) {
           child = child.getWrappedInstance();
         }
         return child;
@@ -102,36 +102,54 @@ exports.default = function () {
         // Render the new children
         this.state['child' + this.state.nextChild] = nextChild;
         this.forceUpdate(function () {
-          var child = _this2.getRef('child' + _this2.state.nextChild);
-          var dom = ReactDom.findDOMNode(child);
+          var prevChild = _this2.getRef('child' + (_this2.state.nextChild === 1 ? 2 : 1));
+          var newChild = _this2.getRef('child' + _this2.state.nextChild);
+          var prevChildDom = ReactDom.findDOMNode(prevChild);
+          var newChildDom = ReactDom.findDOMNode(newChild);
           var timeout = 0;
 
           // Before add appear class
           var willStart = function willStart() {
-            if (child.onTransitionWillStart) {
-              return child.onTransitionWillStart(_this2.props.data) || Promise.resolve();
+            if (newChild.onTransitionWillStart) {
+              return newChild.onTransitionWillStart(_this2.props.data) || Promise.resolve();
+            }
+            if (prevChild && prevChild.onTransitionLeaveWillStart) {
+              return prevChild.onTransitionLeaveWillStart(_this2.props.data) || Promise.resolve();
             }
             return Promise.resolve();
           };
 
           // Add appear class and active class (or trigger manual start)
           var start = function start() {
-            if (dom.classList.contains('transition-item')) {
+            if (newChildDom.classList.contains('transition-item')) {
               timeout = _this2.props.timeout || DEFAULT_TIMEOUT;
-              dom.classList.add('transition-appear');
-              dom.offsetHeight; // Trigger layout to make sure transition happen
-              if (child.transitionManuallyStart) {
-                return child.transitionManuallyStart(_this2.props.data, start) || Promise.resolve();
+              newChildDom.classList.add('transition-appear');
+              newChildDom.offsetHeight; // Trigger layout to make sure transition happen
+              if (newChild.transitionManuallyStart) {
+                return newChild.transitionManuallyStart(_this2.props.data, start) || Promise.resolve();
               }
-              dom.classList.add('transition-appear-active');
+              newChildDom.classList.add('transition-appear-active');
+            }
+            if (prevChildDom) {
+              prevChildDom.classList.add('transition-leave');
+              prevChildDom.classList.add('transition-item');
+              timeout = _this2.props.timeout || DEFAULT_TIMEOUT;
+              prevChildDom.offsetHeight; // Trigger layout to make sure transition happen
+              if (prevChild.transitionManuallyLeaveStart) {
+                return prevChild.transitionManuallyLeaveStart(_this2.props.data, start) || Promise.resolve();
+              }
+              prevChildDom.classList.add('transition-leave-active');
             }
             return Promise.resolve();
           };
 
           // After add classes
           var didStart = function didStart() {
-            if (child.onTransitionDidStart) {
-              return child.onTransitionDidStart(_this2.props.data) || Promise.resolve();
+            if (newChild.onTransitionDidStart) {
+              return newChild.onTransitionDidStart(_this2.props.data) || Promise.resolve();
+            }
+            if (prevChild && prevChild.onTransitionDidStartLeave) {
+              return prevChild.onTransitionLeaveDidStart(_this2.props.data) || Promise.resolve();
             }
             return Promise.resolve();
           };
@@ -150,22 +168,34 @@ exports.default = function () {
 
           // Before remove classes
           var willEnd = function willEnd() {
-            if (child.onTransitionWillEnd) {
-              return child.onTransitionWillEnd(_this2.props.data) || Promise.resolve();
+            if (newChild.onTransitionWillEnd) {
+              return newChild.onTransitionWillEnd(_this2.props.data) || Promise.resolve();
+            }
+            if (prevChild && prevChild.onTransitionLeaveWillEnd) {
+              return prevChild.onTransitionLeaveWillEnd(_this2.props.data) || Promise.resolve();
             }
             return Promise.resolve();
           };
 
           // Remove appear and active class (or trigger manual end)
           var end = function end() {
-            if (dom.classList.contains('transition-item')) {
-              dom.classList.remove('transition-appear');
-              dom.classList.remove('transition-item');
+            if (newChildDom.classList.contains('transition-item')) {
+              newChildDom.classList.remove('transition-appear');
+              newChildDom.classList.remove('transition-item');
 
-              if (child.transitionManuallyStop) {
-                return child.transitionManuallyStop(_this2.props.data) || Promise.resolve();
+              if (newChild.transitionManuallyStop) {
+                return newChild.transitionManuallyStop(_this2.props.data) || Promise.resolve();
               }
-              dom.classList.remove('transition-appear-active');
+              newChildDom.classList.remove('transition-appear-active');
+            }
+            if (prevChildDom && prevChildDom.classList.contains('transition-item')) {
+              prevChildDom.classList.remove('transition-leave');
+              prevChildDom.classList.remove('transition-item');
+
+              if (prevChild.transitionLeaveManuallyStop) {
+                return prevChild.transitionLeaveManuallyStop(_this2.props.data) || Promise.resolve();
+              }
+              prevChildDom.classList.remove('transition-leave-active');
             }
             return Promise.resolve();
           };
@@ -174,8 +204,11 @@ exports.default = function () {
           var didEnd = function didEnd() {
             _this2.props.onLoad && _this2.props.onLoad();
 
-            if (child.onTransitionDidEnd) {
-              return child.onTransitionDidEnd(_this2.props.data) || Promise.resolve();
+            if (newChild.onTransitionDidEnd) {
+              return newChild.onTransitionDidEnd(_this2.props.data) || Promise.resolve();
+            }
+            if (prevChild && prevChild.onTransitionLeaveDidEnd) {
+              return prevChild.onTransitionLeaveDidEnd(_this2.props.data) || Promise.resolve();
             }
             return Promise.resolve();
           };

--- a/src/PageTransition.jsx
+++ b/src/PageTransition.jsx
@@ -98,8 +98,8 @@ export default (
           prevChildDom.classList.add('transition-item');
           timeout = this.props.timeout || DEFAULT_TIMEOUT;
           prevChildDom.offsetHeight; // Trigger layout to make sure transition happen
-          if (prevChild.transitionManuallyLeaveStart) {
-            return prevChild.transitionManuallyLeaveStart(this.props.data, start) ||
+          if (prevChild.transitionLeaveManuallyStart) {
+            return prevChild.transitionLeaveManuallyStart(this.props.data, start) ||
               Promise.resolve();
           }
           prevChildDom.classList.add('transition-leave-active');

--- a/src/PageTransition.jsx
+++ b/src/PageTransition.jsx
@@ -62,36 +62,36 @@ export default (
     // Render the new children
     this.state[`child${this.state.nextChild}`] = nextChild;
     this.forceUpdate(() => {
-      const child = this.getRef(`child${this.state.nextChild}`);
-      const dom = ReactDom.findDOMNode(child);
+      const newChild = this.getRef(`child${this.state.nextChild}`);
+      const newChildDom = ReactDom.findDOMNode(newChild);
       let timeout = 0;
 
       // Before add appear class
       const willStart = () => {
-        if (child.onTransitionWillStart) {
-          return child.onTransitionWillStart(this.props.data) || Promise.resolve();
+        if (newChild.onTransitionWillStart) {
+          return newChild.onTransitionWillStart(this.props.data) || Promise.resolve();
         }
         return Promise.resolve();
       };
 
       // Add appear class and active class (or trigger manual start)
       const start = () => {
-        if (dom.classList.contains('transition-item')) {
+        if (newChildDom.classList.contains('transition-item')) {
           timeout = this.props.timeout || DEFAULT_TIMEOUT;
-          dom.classList.add('transition-appear');
-          dom.offsetHeight; // Trigger layout to make sure transition happen
-          if (child.transitionManuallyStart) {
-            return child.transitionManuallyStart(this.props.data, start) || Promise.resolve();
+          newChildDom.classList.add('transition-appear');
+          newChildDom.offsetHeight; // Trigger layout to make sure transition happen
+          if (newChild.transitionManuallyStart) {
+            return newChild.transitionManuallyStart(this.props.data, start) || Promise.resolve();
           }
-          dom.classList.add('transition-appear-active');
+          newChildDom.classList.add('transition-appear-active');
         }
         return Promise.resolve();
       };
 
       // After add classes
       const didStart = () => {
-        if (child.onTransitionDidStart) {
-          return child.onTransitionDidStart(this.props.data) || Promise.resolve();
+        if (newChild.onTransitionDidStart) {
+          return newChild.onTransitionDidStart(this.props.data) || Promise.resolve();
         }
         return Promise.resolve();
       };
@@ -108,22 +108,22 @@ export default (
 
       // Before remove classes
       const willEnd = () => {
-        if (child.onTransitionWillEnd) {
-          return child.onTransitionWillEnd(this.props.data) || Promise.resolve();
+        if (newChild.onTransitionWillEnd) {
+          return newChild.onTransitionWillEnd(this.props.data) || Promise.resolve();
         }
         return Promise.resolve();
       };
 
       // Remove appear and active class (or trigger manual end)
       const end = () => {
-        if (dom.classList.contains('transition-item')) {
-          dom.classList.remove('transition-appear');
-          dom.classList.remove('transition-item');
+        if (newChildDom.classList.contains('transition-item')) {
+          newChildDom.classList.remove('transition-appear');
+          newChildDom.classList.remove('transition-item');
 
-          if (child.transitionManuallyStop) {
-            return child.transitionManuallyStop(this.props.data) || Promise.resolve();
+          if (newChild.transitionManuallyStop) {
+            return newChild.transitionManuallyStop(this.props.data) || Promise.resolve();
           }
-          dom.classList.remove('transition-appear-active');
+          newChildDom.classList.remove('transition-appear-active');
         }
         return Promise.resolve();
       };
@@ -132,8 +132,8 @@ export default (
       const didEnd = () => {
         this.props.onLoad && this.props.onLoad();
 
-        if (child.onTransitionDidEnd) {
-          return child.onTransitionDidEnd(this.props.data) || Promise.resolve();
+        if (newChild.onTransitionDidEnd) {
+          return newChild.onTransitionDidEnd(this.props.data) || Promise.resolve();
         }
         return Promise.resolve();
       };


### PR DESCRIPTION
We can now define `transition-leave` and `transition-leave-active` in CSS.

New callbacks:
- onTransitionLeaveWillStart
- transitionLeaveManuallyStart
- onTransitionLeaveDidStart
- onTransitionLeaveWillEnd
- transitionLeaveManuallyStop
- onTransitionLeaveDidEnd

![rrpt-leave](https://cloud.githubusercontent.com/assets/4214509/22519594/709cbdc6-e8e3-11e6-9e35-1182e6121e27.gif)


```less
.detail-page {
  overflow: auto;
  box-sizing: border-box;
  padding: 20px;
  height: 100vh;
  background-color: #03a9f4;
  transition: transform 0.5s, opacity 0.5s;

  &.transition-appear {
    opacity: 0;
    transform: translate3d(100%, 0, 0);
  }

  &.transition-appear.transition-appear-active {
    opacity: 1;
    transform: translate3d(0, 0, 0);
  }
  &.transition-leave {
    opacity: 1;
    transform: translate3d(0, 0, 0);
  }

  &.transition-leave.transition-leave-active {
    opacity: 0;
    transform: translate3d(100%, 0, 0);
  }
}

```