### PR TITLE
Add PropTypes and props.compareChildren

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     "less-loader": "^2.2.3",
     "opn": "^4.0.2",
     "postcss-loader": "^0.9.1",
+    "prop-types": "^15.5.10",
     "randomcolor": "^0.4.4",
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0",
     "react-hot-loader": "^1.3.0",
     "react-router": "^2.5.2",
     "rx": "^4.1.0",
@@ -71,9 +74,7 @@
     "template-html-loader": "0.0.3",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1",
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0"
+    "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
     "promise-queue": "^2.2.3"


### PR DESCRIPTION
This PR adds PropTypes and defaultProps and adds props.compareChildren (I need it in case using ReactRouter v4, when this.props.children === nextProps.children, because children is single instance of Switch element).
#24 